### PR TITLE
foobar2000-shellext: Creating a symlink in %AppData%

### DIFF
--- a/bucket/foobar2000-shellext.json
+++ b/bucket/foobar2000-shellext.json
@@ -37,17 +37,23 @@
         ]
     },
     "post_install": [
-        "if (!(Test-Path \"$persist_dir\\profile\\*\")) {",
-        "    Get-ChildItem -Path \"$persist_dir\" -Exclude \"profile\" | Move-Item -Destination \"$persist_dir\\profile\" -Force",
+        "info '[Portable Mode]: Copying user data...'",
+        "if (Test-Path \"$env:AppData\\foobar2000-v2\") {",
+        "    if (Test-Path \"$env:AppData\\foobar2000\") {",
+        "        Rename-Item \"$env:AppData\\foobar2000\" \"$env:AppData\\foobar2000.bak\" -Force",
+        "    }",
+        "    New-Item -ItemType Container -Path \"$persist_dir\\profile\" -Force",
+        "    Copy-Item \"$env:AppData\\foobar2000-v2\\*\" -Destination \"$persist_dir\\profile\" -Force",
+        "    Rename-Item \"$env:AppData\\foobar2000-v2\" \"$env:AppData\\foobar2000-v2.bak\" -Force",
+        "    info \"[Portable Mode]: Your foobar2000 user data that was previously located in\"",
+        "    info \"[Portable Mode]: '$env:AppData\foobar2000' has been migrated to the persist directory.\"",
+        "    info \"[Portable Mode]: In '$env:AppData', there is the backup folder (foobar2000.bak) for your user data'\"",
+        "    info \"[Portable Mode]: and the symlink of persist folder. You may delete the backup folder if it is not needed.\"",
         "}",
-        "if (!(Test-Path \"$persist_dir\\profile\\*\") -and (Test-Path \"$env:AppData\\foobar2000\")) {",
-        "    info '[Portable Mode]: Copying user data...'",
-        "    Copy-Item \"$env:AppData\\foobar2000\\*\" -Destination \"$persist_dir\\profile\" -Force -Recurse",
-        "}",
-        "if (!(Test-Path \"$persist_dir\\profile\\playlists-v1.4\")) {",
-        "    Get-ChildItem -Path \"$persist_dir\\profile\" -Filter \"playlists\" -Directory | Rename-Item -NewName \"playlists-v1.4\" -Force",
-        "}",
-        "Get-ChildItem -Path \"$persist_dir\\profile\" -Filter \"playlists\" | Remove-Item -Force -Recurse"
+        "New-Item -ItemType Junction -Path \"$env:AppData\\foobar2000-v2\" -Target \"$persist_dir\\profile\" -Force",
+        "if (!(Test-Path \"$persist_dir\\profile\\playlists-v2.0\")) {",
+        "    Get-ChildItem -Path \"$persist_dir\\profile\" -Filter \"playlists\" -Directory | Rename-Item -NewName \"playlists-v2.0\" -Force",
+        "}"
     ],
     "bin": "foobar2000.exe",
     "shortcuts": [
@@ -55,6 +61,11 @@
             "foobar2000.exe",
             "Foobar2000"
         ]
+    ],
+    "post_uninstall": [
+        "if ($cmd -eq 'uninstall') {",
+        "    Remove-Item \"$env:AppData\\foobar2000-v2\" -Force -ErrorAction SilentlyContinue",
+        "}"
     ],
     "persist": "profile",
     "checkver": {

--- a/bucket/foobar2000-shellext.json
+++ b/bucket/foobar2000-shellext.json
@@ -9,8 +9,20 @@
     "suggest": {
         "Encoders": "mint/foobar2000-shellext-encoders"
     },
-    "url": "https://www.foobar2000.org/files/foobar2000_v2.0.exe#/dl.7z_",
-    "hash": "bd6aab01d782680f6eb481fa72d5fab474b45bb76b225708eabc9b3c2456332b",
+    "architecture": {
+        "64bit": {
+            "url": "https://www.foobar2000.org/files/foobar2000-x64_v2.0.exe#/dl.7z_",
+            "hash": "91a7ec18a2a35c89b9cce027695a63831e1388047010561f3a0b30c7cfd3994c"
+        },
+        "32bit": {
+            "url": "https://www.foobar2000.org/files/foobar2000_v2.0.exe#/dl.7z_",
+            "hash": "bd6aab01d782680f6eb481fa72d5fab474b45bb76b225708eabc9b3c2456332b"
+        },
+        "arm64": {
+            "url": "https://www.foobar2000.org/files/foobar2000-arm64ec_v2.0.exe#/dl.7z_",
+            "hash": "9224f0ead8a56512140e0e375bb01d20e48ac7b8f044fb455e23fca7ca017325"
+        }
+    },
     "installer": {
         "script": [
             "Expand-7zipArchive \"$dir\\dl.7z_\" \"$dir\" -Overwrite Rename | Out-Null",
@@ -50,6 +62,16 @@
         "regex": "foobar2000_v([\\d.]+)\\."
     },
     "autoupdate": {
-        "url": "https://www.foobar2000.org/files/foobar2000_v$version.exe#/dl.7z_"
+        "architecture": {
+            "64bit": {
+                "url": "https://www.foobar2000.org/files/foobar2000-x64_v$version.exe#/dl.7z_"
+            },
+            "32bit": {
+                "url": "https://www.foobar2000.org/files/foobar2000_v$version.exe#/dl.7z_"
+            },
+            "arm64": {
+                "url": "https://www.foobar2000.org/files/foobar2000-arm64ec_v$version.exe#/dl.7z_"
+            }
+        }
     }
 }


### PR DESCRIPTION
In version < 2.0, the default location for storing user data was $dir/profile,
even if the file $dir/portable_mode_enabled did not exist. However, in version
2.0, this default path was changed to $env:AppData/foobar2000-v2.

To resolve this issue, we first create a profile folder in $persist_dir
and then create a symlink in $AppData/foobar2000-v2. The existing user data
will be migrated accordingly.

This closes #3.